### PR TITLE
ci: Remove unneeded workspace flag and add verbose flag

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --workspace -- --check
+          args: --verbose -- --check
 
   clippy:
     name: Clippy


### PR DESCRIPTION
Simply `cargo fmt` should work on all workspace members. (https://github.com/rust-lang/rustfmt/pull/2295)
Fixes the failing Rustfmt job (https://github.com/PaxyHub/Paxy/actions/runs/3776287850/jobs/6419469159)

Also added `--verbose` flag.